### PR TITLE
DECISION 15332 async validation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/platform-browser": "~4.3.6",
     "@angular/platform-browser-dynamic": "~4.3.6",
     "@types/jasmine": "2.5.54",
-    "@types/node": "^8.0.26",
+    "@types/node": "^9.6.0",
     "camelcase": "^4.0.0",
     "concurrently": "3.5.0",
     "core-js": "^2.4.1",

--- a/src/lib/src/directive/abstract-fx-form.directive.ts
+++ b/src/lib/src/directive/abstract-fx-form.directive.ts
@@ -23,8 +23,8 @@ export abstract class AbstractFxDirective implements OnInit, OnDestroy {
     this.subscriber.subscribe(this.observable,
       v => this.control.valid ? this.ngModelValidValueDebounceStarted.next(v) : null);
 
-    this.subscriber.subscribe(this.observable.debounceTime(this.ngModelValidChangeDebounce),
-      v => this.control.valid ? this.ngModelValidChange.emit(v) : null);
+    this.subscriber.subscribe(this.control.statusChanges.debounceTime(this.ngModelValidChangeDebounce),
+      v => this.control.valid && !this.control.pristine ? this.ngModelValidChange.emit(this.control.value) : null);
   }
 
   ngOnDestroy() {

--- a/src/lib/src/directive/fx-form.directive.spec.ts
+++ b/src/lib/src/directive/fx-form.directive.spec.ts
@@ -1,7 +1,7 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsExtensionModule} from '../forms-extension.module';
 import {Component, ViewChild} from '@angular/core';
-import {NgForm} from '@angular/forms';
+import {NgControl, NgForm} from '@angular/forms';
 import {FxForm} from './fx-form.directive';
 
 describe('FxFormDirective', () => {
@@ -16,8 +16,10 @@ describe('FxFormDirective', () => {
   })
   class NestedFormComponent {
     @ViewChild(FxForm) fxForm: FxForm;
+    @ViewChild(NgControl) nestedInput: NgControl;
     value = 'nested-value';
   }
+
   @Component({
     selector: 'inner1',
     template: `
@@ -52,6 +54,7 @@ describe('FxFormDirective', () => {
   })
   class TestComponent {
     @ViewChild(NgForm) ngForm: NgForm;
+    @ViewChild(NgControl) input: NgControl;
     @ViewChild(FxForm) fxForm: FxForm;
     @ViewChild(InnerForm1Component) inner1: InnerForm1Component;
     @ViewChild(InnerForm2Component) inner2: InnerForm2Component;
@@ -101,6 +104,7 @@ describe('FxFormDirective', () => {
     it('should emit (ngFormValidChange) when inner value changes value and valid', async(() => {
       const formValidChange = spyOn(instance.fxForm.ngFormValidChange, 'emit');
       instance.inner1.nested.value = 'a valid value'; // valid as it's longer than min 3
+      instance.inner1.nested.nestedInput.control.markAsDirty();
       fixture.detectChanges();
       fixture.whenStable().then(() => expect(formValidChange).toHaveBeenCalledTimes(1));
     }));
@@ -108,6 +112,7 @@ describe('FxFormDirective', () => {
     it('should emit (ngFormValidChange) when a field in the parent value changes value and valid', async(() => {
       const formValidChange = spyOn(instance.fxForm.ngFormValidChange, 'emit');
       instance.value = 'a valid value'; // valid as it's longer than min 3
+      instance.input.control.markAsDirty();
       fixture.detectChanges();
       fixture.whenStable().then(() => expect(formValidChange).toHaveBeenCalledTimes(1));
     }));

--- a/src/lib/src/directive/fx-model.directive.spec.ts
+++ b/src/lib/src/directive/fx-model.directive.spec.ts
@@ -51,6 +51,7 @@ describe('FxFormModelDirective', () => {
   [true, false].forEach(valid =>
     it(`should ${valid ? '' : 'NOT'} be valid when [ngModel] is ${valid ? '' : 'NOT'}`, async(() => {
       instance.value = valid ? 'filling in a required field' : '';
+      instance.markAsDirty();
       fixture.detectChanges();
       fixture.whenStable().then(() => expect(hybridFormModel.valid).toBe(valid));
     })));
@@ -106,6 +107,7 @@ describe('FxFormModelDirective', () => {
 
         it('should emit that the model has changed and is valid (ngModelValidChange)', async(() => {
           instance.ngModel.update.emit('a valid change');
+          instance.markAsDirty();
           fixture.detectChanges();
           fixture.whenStable().then(() => expect(ngModelValidChange).toHaveBeenCalledWith(instance.value));
         }));
@@ -123,10 +125,10 @@ describe('FxFormModelDirective', () => {
 
         it(`should debounce for ${FxForm.defaultValidValueChangeDebounce}ms before emitting (ngModelValidChange)`, fakeAsync(() => {
           instance.ngModel.update.emit('a valid change');
+          instance.markAsDirty();
           fixture.detectChanges();
           tick(FxForm.defaultValidValueChangeDebounce - 1);
-          instance.value = 'another valid change';
-          instance.ngModel.update.emit('a valid change');
+          instance.ngModel.update.emit('another valid change');
           fixture.detectChanges();
           tick(FxForm.defaultValidValueChangeDebounce - 1);
           expect(ngModelValidChange).not.toHaveBeenCalledWith(instance.value);
@@ -145,6 +147,7 @@ describe('FxFormModelDirective', () => {
         ngModelValidValueDebounceStarted = spyOn(hybridFormModel.ngModelValidValueDebounceStarted, 'next');
         ngModelValidChange = spyOn(hybridFormModel.ngModelValidChange, 'emit');
         instance.value = 'sh'; // invalid - it's too short as [minLength]=3
+        instance.markAsDirty();
         fixture.detectChanges();
       }));
 

--- a/src/lib/src/directive/valid-submit.directive.spec.ts
+++ b/src/lib/src/directive/valid-submit.directive.spec.ts
@@ -44,7 +44,7 @@ describe('ValidSubmitDirective', () => {
     });
   }));
 
-  it('should not emit (validSubmit) when form is valid', async(() => {
+  it('should emit (validSubmit) when form is valid', async(() => {
     instance.value = 'some new valid value';
     fixture.detectChanges();
     fixture.whenStable().then(() => {


### PR DESCRIPTION
1. changed implementation to subscribe to status changes and checking value instead of subscribing to value changes and then checking validity status.
2. fixed tests that changing control value programmtically, now they mark the control as dirty.
3. need to add tests with async validator